### PR TITLE
Update dependencies to support latest Node (5.1.1)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,5 +1,5 @@
 var restify         = require('restify'),
-  stringFormat      = require('string-format'),
+  stringFormat      = require('string-format').extend(String.prototype, {}),
   assert            = require('assert-plus'),
   _                 = require('underscore'),
   querystring       = require('querystring'),

--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
     "url": "https://github.com/sheknows/node-edgecast/issues"
   },
   "dependencies": {
-    "restify": "~2.6.0",
-    "string-format": "~0.2.1",
-    "assert-plus": "~0.1.5",
-    "underscore": "~1.5.2"
+    "restify": "~4.0.3",
+    "string-format": "~0.5.0",
+    "assert-plus": "~0.2.0",
+    "underscore": "~1.8.3"
   },
   "devDependencies": {
-    "mocha": "~1.15.1",
-    "should": "~2.1.1"
+    "mocha": "~2.3.4",
+    "should": "~8.0.0"
   }
 }


### PR DESCRIPTION
The one that especially caused issues on latest node is restify, which was several versions behind and needed to be updated because of its native extensions. Might as well update the other dependencies while we're at it, though.